### PR TITLE
Cpm update

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -338,5 +338,6 @@ module.exports = {
     audienceInputToTargetingRules,
     slotRulesInputToTargetingRules,
     getSuggestedPricingBounds,
-    userInputPricingBoundsPerMileToRulesValue
+    userInputPricingBoundsPerMileToRulesValue,
+    useInputValuePerMileToTokenValue
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -316,9 +316,9 @@ const useInputValuePerMileToTokenValue = ({ value, decimals, divBy = 1, mulBy = 
         .toString()
 }
 
-const bondPerActionToUserInputPerMileValue = (actionValue) => {
+const bondPerActionToUserInputPerMileValue = (actionValue, decimals = 0) => {
     // hax instead bigNumberify
-    return formatUnits(parseUnits(actionValue, 0).mul(1000)).toString()
+    return formatUnits(parseUnits(actionValue, 0).mul(1000), decimals).toString()
 }
 
 const userInputPricingBoundsPerMileToRulesValue = ({ pricingBounds, decimals, minCoef = 1, maxCoef = 1 }) => {
@@ -351,6 +351,8 @@ const pricingBondsToUserInputPerMile = ({ pricingBounds, decimals }) => {
             max: bondPerActionToUserInputPerMileValue(pricingBounds.IMPRESSION.max, decimals)
         }
     }
+
+    return pricingBoundsCPMUserInput
 }
 
 module.exports = {
@@ -366,5 +368,4 @@ module.exports = {
     useInputValuePerMileToTokenValue,
     pricingBondsToUserInputPerMile,
     bondPerActionToUserInputPerMileValue,
-    pricingBondsToUserInputPerMile
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -311,6 +311,11 @@ const useInputValuePerMileToTokenValue = (value, decimals) => {
     return parseUnits(value, decimals).div(1000).toString()
 }
 
+const bondPerActionToUserInputPerMileValue = (actionValue, decimals) => {
+    // hax instead bigNumberify
+    return  formatUnits(parseUnits(actionValue, 0).mul(1000)).toString()
+}
+
 const userInputPricingBoundsPerMileToRulesValue = ({ pricingBounds, decimals }) => {
     if (!pricingBounds) {
         throw new Error('ERR_PRICING_BOUNDS_NOT_PROVIDED')
@@ -329,6 +334,21 @@ const userInputPricingBoundsPerMileToRulesValue = ({ pricingBounds, decimals }) 
     return pricingBoundsInRuleValue
 }
 
+const pricingBondsToUserInputPerMile = ({pricingBounds, decimals}) => {
+    if (!pricingBounds) {
+        throw new Error('ERR_PRICING_BOUNDS_NOT_PROVIDED')
+    } else if (!pricingBounds.IMPRESSION) {
+        throw new Error('ERR_PRICING_BOUNDS_IMPRESSION_NOT_PROVIDED')
+    }
+
+    const pricingBoundsCPMUserInput = {
+        IMPRESSION: {
+            min: bondPerActionToUserInputPerMileValue(pricingBounds.IMPRESSION.min, decimals),
+            max: bondPerActionToUserInputPerMileValue(pricingBounds.IMPRESSION.max, decimals)
+        }
+    }
+}
+
 module.exports = {
     ipfsHashTo32BytesHex,
     from32BytesHexIpfs,
@@ -339,5 +359,8 @@ module.exports = {
     slotRulesInputToTargetingRules,
     getSuggestedPricingBounds,
     userInputPricingBoundsPerMileToRulesValue,
-    useInputValuePerMileToTokenValue
+    useInputValuePerMileToTokenValue,
+    pricingBondsToUserInputPerMile,
+    bondPerActionToUserInputPerMileValue,
+    pricingBondsToUserInputPerMile
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -237,11 +237,7 @@ const getPriceRulesV1 = ({ audienceInput, countryTiersCoefficients, pricingBound
         if (multiplier !== 1 || isTopSelectedTier) {
 
             const price = isTopSelectedTier ? userPricingBounds.max : userPricingBounds.min * multiplier
-            console.log('price', price)
-
             const tierPrice = getClampedNumber(price, userPricingBounds.min, userPricingBounds.max)
-            console.log('tierPrice', tierPrice)
-
 
             rules.push({
                 if: [

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -252,7 +252,7 @@ const getPriceRulesV1 = ({ audienceInput, countryTiersCoefficients, pricingBound
     return rules
 }
 
-// pricingBounds per action BM string
+// pricingBounds per action BN string
 const audienceInputToTargetingRules = ({ audienceInput, minByCategory, countryTiersCoefficients, pricingBounds, decimals }) => {
     if (audienceInput.version === '1') {
         const { inputs } = audienceInput
@@ -304,7 +304,7 @@ const slotRulesInputToTargetingRules = ({ rulesInput, suggestedMinCPM, decimals 
     throw new Error('INVALID_RULES_INPUT_VERSION')
 }
 
-const useInputValuePerMileToTokenValue = ({ value, decimals, divBy = 1, mulBy = 1 } = {}) => {
+const userInputValuePerMileToTokenValue = ({ value, decimals, divBy = 1, mulBy = 1 } = {}) => {
     return parseUnits(value, decimals)
         .mul(mulBy || 1)
         .div(1000)
@@ -326,8 +326,8 @@ const userInputPricingBoundsPerMileToRulesValue = ({ pricingBounds, decimals, mi
 
     const pricingBoundsInRuleValue = {
         IMPRESSION: {
-            min: useInputValuePerMileToTokenValue({ value: pricingBounds.IMPRESSION.min, decimals, divBy: minCoef }),
-            max: useInputValuePerMileToTokenValue({ value: pricingBounds.IMPRESSION.max, decimals, mulBy: maxCoef })
+            min: userInputValuePerMileToTokenValue({ value: pricingBounds.IMPRESSION.min, decimals, divBy: minCoef }),
+            max: userInputValuePerMileToTokenValue({ value: pricingBounds.IMPRESSION.max, decimals, mulBy: maxCoef })
         }
     }
 
@@ -361,7 +361,7 @@ module.exports = {
     slotRulesInputToTargetingRules,
     getSuggestedPricingBounds,
     userInputPricingBoundsPerMileToRulesValue,
-    useInputValuePerMileToTokenValue,
+    userInputValuePerMileToTokenValue,
     pricingBondsToUserInputPerMile,
     bondPerActionToUserInputPerMileValue,
 }

--- a/src/models/Audience.js
+++ b/src/models/Audience.js
@@ -2,7 +2,7 @@ const Base = require('./Base')
 
 class Audience extends Base {
     constructor({
-        id = '',        
+        id = '',
         campaignId = null,
         version = '1',
         inputs = {},
@@ -10,6 +10,7 @@ class Audience extends Base {
         created = null,
         modified = null,
         title = '',
+        pricingBoundsCPMUserInput = null,
         description = '',
         archived = false,
         temp = {},
@@ -24,6 +25,7 @@ class Audience extends Base {
         this.created = created
         this.modified = modified
         this.title = title
+        this.pricingBoundsCPMUserInput = pricingBoundsCPMUserInput
         this.description = description
         this.archived = archived
         this.temp = temp
@@ -33,19 +35,22 @@ class Audience extends Base {
 
     get marketAdd() {
         return this.deepCopyObj({
-            campaignId: this. campaignId,
+            campaignId: this.campaignId,
             version: this.version,
             inputs: this.inputs,
             title: this.title,
+            pricingBoundsCPMUserInput: this.pricingBoundsCPMUserInput
+
         })
     }
 
     get marketDbAdd() {
         return this.deepCopyObj({
-            campaignId: this. campaignId,
+            campaignId: this.campaignId,
             version: this.version,
             inputs: this.inputs,
             title: this.title,
+            pricingBoundsCPMUserInput: this.pricingBoundsCPMUserInput,
             owner: this.owner,
             created: this.created,
         })

--- a/src/models/Campaign.js
+++ b/src/models/Campaign.js
@@ -13,6 +13,7 @@ class Campaign extends Base {
         adUnits = [], // objs with AdUnits spec props
         validators = [], // 2 objs {id: '', url: '', fee: ''} , 1st - leader, 2nd - follower
         pricingBounds = null, //{IMPRESSION: { CLICK: { min: "0", max: "1000" } }}
+        pricingBoundsCPMUserInput = null, // {IMPRESSION: { CLICK: { min: "0", max: "1000" } }} - per mile - divide by 1000 for spec.pricingBonds
         maxPerImpression = '', // BigNumStr // OBSOLETE - TODO: remove
         minPerImpression = '', // BigNumStr // OBSOLETE - TODO: remove
         targeting = [], // {tag: '', score: 0} // OBSOLETE - TODO: remove
@@ -41,6 +42,7 @@ class Campaign extends Base {
         this.adUnits = adUnits
         this.validators = validators
         this.pricingBounds = pricingBounds
+        this.pricingBoundsCPMUserInput = pricingBoundsCPMUserInput
         this.maxPerImpression = maxPerImpression
         this.minPerImpression = minPerImpression
         this.targeting = targeting
@@ -106,6 +108,7 @@ class Campaign extends Base {
             title: this.title,
             targetingRules: this.targetingRules,
             audienceInput: this.audienceInputMarket,
+            pricingBoundsCPMUserInput: this.pricingBoundsCPMUserInput
         })
     }
 
@@ -114,6 +117,7 @@ class Campaign extends Base {
             title: this.title,
             targetingRules: this.targetingRules,
             audienceInput: this.audienceInputMarket,
+            pricingBoundsCPMUserInput: this.pricingBoundsCPMUserInput,
             modified: this.modified,
         })
     }

--- a/src/models/Campaign.js
+++ b/src/models/Campaign.js
@@ -108,7 +108,8 @@ class Campaign extends Base {
             title: this.title,
             targetingRules: this.targetingRules,
             audienceInput: this.audienceInputMarket,
-            pricingBoundsCPMUserInput: this.pricingBoundsCPMUserInput
+            pricingBoundsCPMUserInput: this.pricingBoundsCPMUserInput,
+            pricingBounds: this.pricingBounds
         })
     }
 
@@ -118,6 +119,7 @@ class Campaign extends Base {
             targetingRules: this.targetingRules,
             audienceInput: this.audienceInputMarket,
             pricingBoundsCPMUserInput: this.pricingBoundsCPMUserInput,
+            pricingBounds: this.pricingBounds,
             modified: this.modified,
         })
     }

--- a/src/schemas.js
+++ b/src/schemas.js
@@ -109,7 +109,8 @@ module.exports = {
         audienceInput: Joi.object().keys({
             version: Joi.string().min(1).max(69).required().error(new Error(errors.AUDIENCE_VERSION_ERR)),
             inputs: Joi.object().required().error(new Error(errors.AUDIENCE_INPUTS_ERR)),
-        }).allow(null).optional()
+        }).allow(null).optional(),
+        pricingBoundsCPMUserInput: Joi.object().allow(null).optional()
     },
     account: {
         email: Joi.string().email({ allowUnicode: false }).required().error(new Error(errors.ACCOUNT_EMAIL_ERR)),

--- a/src/schemas.js
+++ b/src/schemas.js
@@ -110,7 +110,8 @@ module.exports = {
             version: Joi.string().min(1).max(69).required().error(new Error(errors.AUDIENCE_VERSION_ERR)),
             inputs: Joi.object().required().error(new Error(errors.AUDIENCE_INPUTS_ERR)),
         }).allow(null).optional(),
-        pricingBoundsCPMUserInput: Joi.object().allow(null).optional()
+        pricingBoundsCPMUserInput: Joi.object().allow(null).optional(),
+        pricingBonds: Joi.object().allow(null).optional(),
     },
     account: {
         email: Joi.string().email({ allowUnicode: false }).required().error(new Error(errors.ACCOUNT_EMAIL_ERR)),
@@ -120,6 +121,7 @@ module.exports = {
         version: Joi.string().min(1).max(69).required().error(new Error(errors.AUDIENCE_VERSION_ERR)),
         inputs: Joi.object().required().error(new Error(errors.AUDIENCE_INPUTS_ERR)),
         title: Joi.string().allow(null).min(3).max(300).optional().error(new Error(errors.AUDIENCE_TITLE_ERR)),
+        pricingBoundsCPMUserInput: Joi.object().allow(null).optional()
     },
     audiencePut: {
         version: Joi.string().min(1).max(69).required().error(new Error(errors.AUDIENCE_VERSION_ERR)),

--- a/src/schemas.js
+++ b/src/schemas.js
@@ -9,7 +9,7 @@ const {
     addressRegex,
     signatureRegex,
     hashRegex,
-    campaignAddrRegex
+    // campaignAddrRegex
 } = require('./validations').Regexes
 const validModes = Object.keys(SignatureModes).map(key => SignatureModes[key])
 const roles = ['advertiser', 'publisher']

--- a/src/schemas.js
+++ b/src/schemas.js
@@ -19,9 +19,29 @@ const roles = ['advertiser', 'publisher']
 const errors = require('./errors')
 const targetUrlSchema = Joi.string().regex(/^((http:\/\/)|(https:\/\/))[\S]+/).uri({ scheme: ['http', 'https'], allowQuerySquareBrackets: true })
 const numericString = Joi.string().regex(/^\d+$/)
+const numericStringFloat = Joi.string().regex(/^(\d|\.)+$/)
 const slotMinPerImpression = Joi.object().allow(null).pattern(/^/, numericString).optional().error(new Error(errors.SLOT_MIN_PER_IMPR))
+
 // TODO: bump celebrate/joi version to add tlsd validations (joi 16+) for slot website
 // That will require update of using .allow([]) (it is not allowed at joi 16+)
+
+const pricingBoundsSchema = Joi.object()
+    .allow(null)
+    .optional()
+    .keys()
+    .pattern(
+        /^(IMPRESSION|CLICK)$/,
+        Joi.object({ min: numericString.required(), max: numericString.required() })
+    )
+
+const pricingBoundsUserInputPMSchema = Joi.object()
+    .allow(null)
+    .optional()
+    .keys()
+    .pattern(
+        /^(IMPRESSION|CLICK)$/,
+        Joi.object({ min: numericStringFloat.required(), max: numericStringFloat.required() })
+    )
 
 module.exports = {
     adSlotPost: {
@@ -40,7 +60,7 @@ module.exports = {
             version: Joi.string().min(1).max(69).required().error(new Error(errors.SLOT_RULES_VERSION_ERR)),
             inputs: Joi.object().required().error(new Error(errors.SLOT_RULES_INPUTS_ERR)),
         }).allow(null).optional(),
-        website: Joi.string().required().regex(/^(https:\/\/)[\S]+/).uri({ scheme: ['http', 'https']}).error(new Error(errors.SLOT_WEBSITE_ERR)),
+        website: Joi.string().required().regex(/^(https:\/\/)[\S]+/).uri({ scheme: ['http', 'https'] }).error(new Error(errors.SLOT_WEBSITE_ERR)),
         archived: Joi.bool().optional().error(new Error(errors.ARCHIVED_ERR)),
         modified: Joi.allow(null).error(new Error(errors.MODIFIED_NOT_NULL_ERR))
     },
@@ -55,7 +75,7 @@ module.exports = {
             inputs: Joi.object().required().error(new Error(errors.SLOT_RULES_INPUTS_ERR)),
         }).allow(null).optional(),
         archived: Joi.bool().optional().error(new Error(errors.ARCHIVED_ERR)),
-        website: Joi.string().allow('').optional().regex(/^(https:\/\/)[\S]+/).uri({ scheme: ['http', 'https']}).error(new Error(errors.SLOT_WEBSITE_ERR)),
+        website: Joi.string().allow('').optional().regex(/^(https:\/\/)[\S]+/).uri({ scheme: ['http', 'https'] }).error(new Error(errors.SLOT_WEBSITE_ERR)),
         // modified: set it on the server
     },
     adUnitPost: {
@@ -110,8 +130,8 @@ module.exports = {
             version: Joi.string().min(1).max(69).required().error(new Error(errors.AUDIENCE_VERSION_ERR)),
             inputs: Joi.object().required().error(new Error(errors.AUDIENCE_INPUTS_ERR)),
         }).allow(null).optional(),
-        pricingBoundsCPMUserInput: Joi.object().allow(null).optional(),
-        pricingBounds: Joi.object().allow(null).optional(),
+        pricingBoundsCPMUserInput: pricingBoundsUserInputPMSchema,
+        pricingBounds: pricingBoundsSchema,
     },
     account: {
         email: Joi.string().email({ allowUnicode: false }).required().error(new Error(errors.ACCOUNT_EMAIL_ERR)),
@@ -121,7 +141,7 @@ module.exports = {
         version: Joi.string().min(1).max(69).required().error(new Error(errors.AUDIENCE_VERSION_ERR)),
         inputs: Joi.object().required().error(new Error(errors.AUDIENCE_INPUTS_ERR)),
         title: Joi.string().allow(null).min(3).max(300).optional().error(new Error(errors.AUDIENCE_TITLE_ERR)),
-        pricingBoundsCPMUserInput: Joi.object().allow(null).optional()
+        pricingBoundsCPMUserInput: pricingBoundsUserInputPMSchema
     },
     audiencePut: {
         version: Joi.string().min(1).max(69).required().error(new Error(errors.AUDIENCE_VERSION_ERR)),

--- a/src/schemas.js
+++ b/src/schemas.js
@@ -111,7 +111,7 @@ module.exports = {
             inputs: Joi.object().required().error(new Error(errors.AUDIENCE_INPUTS_ERR)),
         }).allow(null).optional(),
         pricingBoundsCPMUserInput: Joi.object().allow(null).optional(),
-        pricingBonds: Joi.object().allow(null).optional(),
+        pricingBounds: Joi.object().allow(null).optional(),
     },
     account: {
         email: Joi.string().email({ allowUnicode: false }).required().error(new Error(errors.ACCOUNT_EMAIL_ERR)),


### PR DESCRIPTION
- added helpers to convert user pricing bounds as CPM input to rules value and vice versa `pricingBondsToUserInputPerMile`, `userInputPricingBoundsPerMileToRulesValue`
- added `pricingBoundsCPMUserInput` to `Audience` and `Campaign` models
- added `pricinBounds` and `pricingBoundsCPMUserInput` to `Campaign` PUT schema
- added `pricingBoundsCPMUserInput` to audience POST schema