### PR TITLE
Cpm update fix

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -225,6 +225,10 @@ const getPriceRulesV1 = ({ audienceInput, countryTiersCoefficients, pricingBound
 
     const rules = []
 
+    rules.push(
+        { set: ['price.IMPRESSION', { bn: parseUnits(userPricingBounds.min.toFixed(8), decimals).toString() }] }
+    )
+
     // Add price rules for each tier
     Object.values(selectedTiers).forEach(tier => {
         const multiplier = (normalizedCountryTiersCoefficients[tier.ruleValue])

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -180,13 +180,14 @@ const getSelectedCountryTiersFormAudienceInput = (location) => {
         )
     } else if (apply === 'nin') {
         return Object.fromEntries(Object.entries(CountryTiers)
-            .filter(([key, value]) => {
-                return !location.nin.includes(key) || !value.countries.every(x => location.nin.includes(x))
-            })
             .map(([key, value]) => {
-                const countries = [...value.countries].filter(x => !location.nin.includes(x))
+                const countries = location.nin.includes(key) ? [] : [...value.countries].filter(x => !location.nin.includes(x))
                 return [key, { ...value, countries }]
-            }))
+            })
+            .filter(([key, value]) => {
+                return !!value.countries.length
+            })
+        )
     }
 
     return { ...CountryTiers }
@@ -202,7 +203,6 @@ const getPriceRulesV1 = ({ audienceInput, countryTiersCoefficients, pricingBound
     }
 
     const selectedTiers = getSelectedCountryTiersFormAudienceInput(location)
-
     const selectedTiersOrdered = Object.entries(countryTiersCoefficients)
         .filter(([key, value]) => !!selectedTiers[key])
         .sort((a, b) => a[1] - b[1])
@@ -224,10 +224,6 @@ const getPriceRulesV1 = ({ audienceInput, countryTiersCoefficients, pricingBound
     const topSelectedTier = selectedTiersOrdered.pop()[0]
 
     const rules = []
-
-    rules.push(
-        { set: ['price.IMPRESSION', { bn: parseUnits(userPricingBounds.min.toFixed(8), decimals).toString() }] }
-    )
 
     // Add price rules for each tier
     Object.values(selectedTiers).forEach(tier => {
@@ -264,6 +260,8 @@ const audienceInputToTargetingRules = ({ audienceInput, minByCategory, countryTi
         const allCountriesSelected = location.apply === 'allin' || areAllCountriesSelected(location[location.apply])
         const allDevicesSelected = devices.apply === 'allin' || areAllDevicesSelected(devices[devices.apply])
         const rules = [
+            // Set base price - required for cpm update
+            { set: ['price.IMPRESSION', { bn: pricingBounds.IMPRESSION.min }] },
             ...(!allCountriesSelected ? [{ onlyShowIf: { [location.apply]: [inputCountriesToRuleCountries(location[location.apply]), { get: 'country' }] } }] : []),
             ...(allCountriesSelected && location.apply === 'in' ? [] : []),
             ...(allCountriesSelected && location.apply === 'nin' ? [{ onlyShowIf: false }] : []),

--- a/src/models/Campaign.js
+++ b/src/models/Campaign.js
@@ -100,6 +100,7 @@ class Campaign extends Base {
         return  this.audienceInput && this.audienceInput.version && Object.keys(this.audienceInput.inputs).length ? this.deepCopyObj({
             version: this.audienceInput.version,
             inputs: this.audienceInput.inputs,
+            pricingBoundsCPMUserInput: this.pricingBoundsCPMUserInput
         }) : null
     }
 
@@ -108,8 +109,6 @@ class Campaign extends Base {
             title: this.title,
             targetingRules: this.targetingRules,
             audienceInput: this.audienceInputMarket,
-            pricingBoundsCPMUserInput: this.pricingBoundsCPMUserInput,
-            pricingBounds: this.pricingBounds
         })
     }
 
@@ -118,8 +117,6 @@ class Campaign extends Base {
             title: this.title,
             targetingRules: this.targetingRules,
             audienceInput: this.audienceInputMarket,
-            pricingBoundsCPMUserInput: this.pricingBoundsCPMUserInput,
-            pricingBounds: this.pricingBounds,
             modified: this.modified,
         })
     }

--- a/src/models/Campaign.js
+++ b/src/models/Campaign.js
@@ -100,7 +100,7 @@ class Campaign extends Base {
         return  this.audienceInput && this.audienceInput.version && Object.keys(this.audienceInput.inputs).length ? this.deepCopyObj({
             version: this.audienceInput.version,
             inputs: this.audienceInput.inputs,
-            pricingBoundsCPMUserInput: this.pricingBoundsCPMUserInput
+            pricingBoundsCPMUserInput: this.pricingBoundsCPMUserInput || this.audienceInput.pricingBoundsCPMUserInput
         }) : null
     }
 

--- a/src/schemas.js
+++ b/src/schemas.js
@@ -129,9 +129,8 @@ module.exports = {
         audienceInput: Joi.object().keys({
             version: Joi.string().min(1).max(69).required().error(new Error(errors.AUDIENCE_VERSION_ERR)),
             inputs: Joi.object().required().error(new Error(errors.AUDIENCE_INPUTS_ERR)),
+            pricingBoundsCPMUserInput: pricingBoundsUserInputPMSchema,
         }).allow(null).optional(),
-        pricingBoundsCPMUserInput: pricingBoundsUserInputPMSchema,
-        pricingBounds: pricingBoundsSchema,
     },
     account: {
         email: Joi.string().email({ allowUnicode: false }).required().error(new Error(errors.ACCOUNT_EMAIL_ERR)),


### PR DESCRIPTION
- Campaign model `pricingBoundsCPMUserInput` to `audienceInput`, update schemas
- fix audience input to tatrting rules when countries are selected to not show (`location.nin`)
- updated and fixed unit tests